### PR TITLE
cleanup: remove dead parameters and unused trader types

### DIFF
--- a/back/api/routes/test.py
+++ b/back/api/routes/test.py
@@ -142,7 +142,6 @@ async def create_test_session(request: Request):
     params_dict["num_noise_traders"] = 1
     params_dict["num_informed_traders"] = 0
     params_dict["predefined_goals"] = [0]
-    params_dict["market_sizes"] = [1]
 
     params = TradingParameters(**params_dict)
     manager = TraderManager(params, market_id=test_session_id)

--- a/back/config/app.yaml
+++ b/back/config/app.yaml
@@ -1,8 +1,3 @@
-# Cohort configuration - set before experiment starts
-# Empty = single cohort with size = len(predefined_goals)
-# Example: [4, 4, 4] = 12 people in 3 groups of 4
-MARKET_SIZES: []
-
 MD_TOKEN: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzZXNzaW9uIjoidmVudm9vb28uZ21haWwuY29tIiwiZW1haWwiOiJ2ZW52b29vb0BnbWFpbC5jb20iLCJ1c2VySWQiOiI4NjIyNzk3YS05ZDkzLTQ0MTYtYjhlNy0wNTdiMDFkNjc1NjEiLCJpYXQiOjE3MDYwNTk3MjgsImV4cCI6MTczNzYxNzMyOH0.QhvzD9nk5C3L-28u5gfZXqJosOvIpV-S6ElKwp5HeU4"
 
 TABLE_REF: "market_parameter"

--- a/back/config/treatments.yaml
+++ b/back/config/treatments.yaml
@@ -1,5 +1,5 @@
 treatments:
-- name: Low
+- name: "1"
   informed_trade_intensity: 0.36
-- name: High
+- name: "2"
   informed_trade_intensity: 0.69

--- a/back/core/data_models.py
+++ b/back/core/data_models.py
@@ -40,7 +40,6 @@ class UserRegistration(BaseModel):
 # trader types
 class TraderType(str, Enum):
     NOISE = "NOISE"
-    MARKET_MAKER = "MARKET_MAKER"
     INFORMED = "INFORMED"
     HUMAN = "HUMAN"
     INITIAL_ORDER_BOOK = "INITIAL_ORDER_BOOK"
@@ -227,26 +226,6 @@ class TradingParameters(BaseModel):
         description="human_parameter",
         ge=1,
     )
-    
-    market_sizes: List[int] = Field(
-        default=[],
-        title="Market Sizes (Cohorts)",
-        description="human_parameter",
-    )
-
-    # session type (prolific or lab)
-    session_type: str = Field(
-        default="prolific",
-        title="Session Type",
-        description="human_parameter",
-    )
-
-    # admin stuff
-    google_form_id: str = Field(
-        default='1yDf7vd5wLaPhm30IiGKTkPw4s5spb3Xlm86Li81YDXI',
-        title="Google Form ID",
-        description="model_parameter",
-    )
 
     # goal settings
     predefined_goals: List[int] = Field(
@@ -266,7 +245,6 @@ class TradingParameters(BaseModel):
             TraderType.HUMAN: ThrottleConfig(order_throttle_ms=100, max_orders_per_window=1),
             TraderType.NOISE: ThrottleConfig(),
             TraderType.INFORMED: ThrottleConfig(),
-            TraderType.MARKET_MAKER: ThrottleConfig(),
             TraderType.INITIAL_ORDER_BOOK: ThrottleConfig(),
         },
         title="Throttle Settings Per Trader Type",
@@ -290,24 +268,6 @@ class TradingParameters(BaseModel):
         else:
             raise ValueError("Predefined goals must be comma-separated string or number list!")
     
-    @field_validator('market_sizes', mode='before')
-    def validate_market_sizes(cls, v):
-        if isinstance(v, str):
-            if not v.strip():
-                return []
-            try:
-                sizes = [int(x.strip()) for x in v.split(',') if x.strip()]
-                return sizes
-            except ValueError:
-                raise ValueError("Market sizes must be comma-separated numbers!")
-        elif isinstance(v, list):
-            if not v:
-                return []
-            sizes = [int(x) for x in v]
-            return sizes
-        else:
-            return []
-
     def dump_params_by_description(self) -> dict:
         """organize params by their type"""
         result = {}

--- a/back/tests/test_cohort_persistence.py
+++ b/back/tests/test_cohort_persistence.py
@@ -94,13 +94,10 @@ treatments:
         await update_settings(
             session,
             predefined_goals=[100, 50, 0],  # 3 goals for 3 participants per cohort
-            market_sizes=[3, 3, 3, 3],       # 4 cohorts of 3 (12 users)
             max_markets_per_human=3,         # 3 markets per participant
             trading_day_duration=0.25,       # 15 seconds
             num_noise_traders=1,
-            num_informed_traders=0,
-            num_spoofing_traders=0,
-            num_manipulator_traders=0
+            num_informed_traders=0
         )
         print("✓ Settings: 4 cohorts of 3, 3 markets each, 15-second duration")
         

--- a/back/tests/test_market_logging.py
+++ b/back/tests/test_market_logging.py
@@ -81,11 +81,9 @@ async def main():
         # Upload a simple treatment
         yaml_content = """
 treatments:
-  - name: "Test Market - Quick"
+  - name: "1"
     num_noise_traders: 1
     num_informed_traders: 0
-    num_spoofing_traders: 0
-    num_manipulator_traders: 0
 """
         await upload_treatments(session, yaml_content)
         print("✓ Uploaded test treatment")
@@ -96,9 +94,7 @@ treatments:
             predefined_goals=[0],  # Single speculator
             trading_day_duration=3,  # 3 seconds
             num_noise_traders=1,
-            num_informed_traders=0,
-            num_spoofing_traders=0,
-            num_manipulator_traders=0
+            num_informed_traders=0
         )
         print("✓ Settings: 3-second market, 1 participant")
         

--- a/back/tests/test_treatments.py
+++ b/back/tests/test_treatments.py
@@ -9,35 +9,17 @@ BACKEND_URL = os.getenv("BACKEND_URL", "http://localhost:8000")
 
 SAMPLE_YAML = """
 treatments:
-  - name: "Market 1 - Noise Only"
+  - name: "1"
     num_noise_traders: 5
     num_informed_traders: 0
-    num_spoofing_traders: 0
-    num_manipulator_traders: 0
-    
-  - name: "Market 2 - With Spoofer"
-    num_noise_traders: 3
-    num_spoofing_traders: 1
-    num_informed_traders: 0
-    num_manipulator_traders: 0
-    
-  - name: "Market 3 - With Informed"
+
+  - name: "2"
     num_noise_traders: 3
     num_informed_traders: 1
-    num_spoofing_traders: 0
-    num_manipulator_traders: 0
-    
-  - name: "Market 4 - With Manipulator"
-    num_noise_traders: 3
-    num_manipulator_traders: 1
-    num_informed_traders: 0
-    num_spoofing_traders: 0
-    
-  - name: "Market 5 - Mixed"
+
+  - name: "3"
     num_noise_traders: 2
-    num_spoofing_traders: 1
-    num_informed_traders: 1
-    num_manipulator_traders: 0
+    num_informed_traders: 2
 """
 
 
@@ -133,7 +115,6 @@ async def test_treatment_lookup():
                 treatment = result.get('next_treatment')
                 if treatment:
                     print(f"  Treatment: noise={treatment.get('num_noise_traders')}, "
-                          f"spoof={treatment.get('num_spoofing_traders')}, "
                           f"informed={treatment.get('num_informed_traders')}")
                 else:
                     print("  Treatment: None (will use base settings)")
@@ -153,9 +134,7 @@ async def test_treatment_application():
             predefined_goals=[0],
             trading_day_duration=0.1,
             num_noise_traders=1,
-            num_informed_traders=0,
-            num_spoofing_traders=0,
-            num_manipulator_traders=0
+            num_informed_traders=0
         )
         print("Base settings: 1 noise trader")
         
@@ -183,11 +162,8 @@ async def test_treatment_application():
             if market_info and market_info.get('status') == 'success':
                 traders = market_info.get('data', {}).get('traders', [])
                 noise_count = sum(1 for t in traders if t.startswith('NOISE_'))
-                spoof_count = sum(1 for t in traders if t.startswith('SPOOFING_'))
                 informed_count = sum(1 for t in traders if t.startswith('INFORMED_'))
-                manip_count = sum(1 for t in traders if t.startswith('MANIPULATOR_'))
-                print(f"Actual traders: noise={noise_count}, spoof={spoof_count}, "
-                      f"informed={informed_count}, manip={manip_count}")
+                print(f"Actual traders: noise={noise_count}, informed={informed_count}")
                 
                 if expected_treatment:
                     expected_noise = expected_treatment.get('num_noise_traders', 1)


### PR DESCRIPTION
## Summary
- Remove `market_sizes` parameter (cohort size now derived from `len(predefined_goals)`)
- Remove `session_type` and `google_form_id` (unused)
- Remove `TraderType.MARKET_MAKER` (no implementation exists)
- Update treatments.yaml to use numeric names ("1", "2") matching T1/T2 lab links
- Clean test files of spoofing/manipulator references

## Changes
- **data_models.py**: -40 lines (dead parameters and validators)
- **treatments.yaml**: "Low"/"High" → "1"/"2"
- **test files**: remove references to non-existent trader types

## Test plan
- [ ] Verify admin panel still loads parameters correctly
- [ ] Verify lab links T1/T2 map to treatments "1"/"2"