### PR TITLE
Fix timer flicker during trading

### DIFF
--- a/front/src/components/TradingDashboard.vue
+++ b/front/src/components/TradingDashboard.vue
@@ -52,8 +52,8 @@
             </div>
             <div class="time-display">
               <vue-countdown
-                v-if="remainingTime"
-                :time="remainingTime * 1000"
+                v-if="countdownTime"
+                :time="countdownTime"
                 v-slot="{ minutes, seconds }"
               >
                 {{ minutes }}:{{ seconds.toString().padStart(2, '0') }}
@@ -162,13 +162,14 @@ const formatDelta = computed(() => {
   return halfChange >= 0 ? '+' + halfChange : halfChange.toString()
 })
 
-const finalizingDay = () => {
-  NavigationService.onTradingEnded()
-}
+const countdownTime = ref(null)
 
 watch(remainingTime, (newValue) => {
+  if (newValue !== null && newValue > 0 && countdownTime.value === null) {
+    countdownTime.value = newValue * 1000
+  }
   if (newValue !== null && newValue <= 0 && isTradingStarted.value) {
-    finalizingDay()
+    NavigationService.onTradingEnded()
   }
 })
 


### PR DESCRIPTION
Ref #24

## Summary

- Timer flickered because `vue-countdown` re-initialized every second when `remainingTime` prop updated via WebSocket `time_update`
- Introduced a `countdownTime` ref that captures the value only once on first receive, then lets `vue-countdown` handle its own internal countdown

## Test plan

- [ ] Start a trading session and verify the timer counts down smoothly without flickering
- [ ] Verify timer still triggers end-of-day navigation when it reaches 0