### PR TITLE
Fix production crash: remove dotenv import

### DIFF
--- a/back/api/endpoints.py
+++ b/back/api/endpoints.py
@@ -10,9 +10,6 @@ so both HTTP/REST routes and Socket.IO events are served on the same port.
 
 import asyncio
 
-from dotenv import load_dotenv
-load_dotenv()
-
 import socketio
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware


### PR DESCRIPTION
Fixes #33

## Summary

- Remove `from dotenv import load_dotenv` from `api/endpoints.py`
- This import was left behind when PR #32 removed `python-dotenv` from dependencies, causing `ModuleNotFoundError` on production startup
- Docker env vars are sufficient; `load_dotenv()` was never needed in containerized deployments

## Test plan

- [x] Local backend starts without errors
- [x] `grep -r dotenv` returns no matches in the codebase
- [ ] Production backend recovers after deploy